### PR TITLE
fix(extension): duplicate post in feed

### DIFF
--- a/packages/extension/src/store/modules/feed.js
+++ b/packages/extension/src/store/modules/feed.js
@@ -155,7 +155,11 @@ export default {
     },
     addPosts(state, { posts, type }) {
       // TODO: add tests
-      state[type] = state[type].concat(posts);
+      if (posts && posts.length > 0) {
+        const postsToAdd = posts[0].id === state[type][state[type].length - 1].id
+          ? posts.slice(1) : posts;
+        state[type] = state[type].concat(postsToAdd);
+      }
     },
     removePost(state, postId) {
       const feed = getFeed(state);


### PR DESCRIPTION
Checks for duplicate post before adding new page to the feed.

Closes dailydotdev/daily#97