### PR TITLE
fix(tooltip): append tooltip to the first scrollable parent

### DIFF
--- a/packages/components/src/common/adMixin.js
+++ b/packages/components/src/common/adMixin.js
@@ -6,8 +6,8 @@ export default {
     },
     selected: {
       type: Boolean,
-      default: false
-    }
+      default: false,
+    },
   },
 
   computed: {

--- a/packages/components/src/common/domHelper.js
+++ b/packages/components/src/common/domHelper.js
@@ -47,7 +47,7 @@ export function getTopLeftMostPostEl(posts, insaneMode) {
   let child = (insaneMode ? parent : parent.parentElement.firstElementChild).firstElementChild;
   let result = getPostByElement(posts, child);
 
-  while(!result && child) {
+  while (!result && child) {
     child = child.nextElementSibling;
     result = getPostByElement(posts, child);
   }
@@ -56,7 +56,7 @@ export function getTopLeftMostPostEl(posts, insaneMode) {
 }
 
 export function hoverPost(selectedPost) {
-  selectedPost.$el.getElementsByClassName(`post__link`)[0].focus();
+  selectedPost.$el.getElementsByClassName('post__link')[0].focus();
 }
 
 export default {
@@ -67,5 +67,5 @@ export default {
   getBelowPost,
   getAbovePost,
   getTopLeftMostPostEl,
-  hoverPost
-}
+  hoverPost,
+};

--- a/packages/components/src/common/postMixin.js
+++ b/packages/components/src/common/postMixin.js
@@ -16,8 +16,8 @@ export default {
     },
     selected: {
       type: Boolean,
-      default: false
-    }
+      default: false,
+    },
   },
 
   data() {

--- a/packages/components/src/components/DaCardAd.vue
+++ b/packages/components/src/components/DaCardAd.vue
@@ -30,8 +30,8 @@ export default {
     cls() {
       return {
         [this.ad.source]: this.ad.source,
-        hover: this.selected
-      }
+        hover: this.selected,
+      };
     },
   },
 };

--- a/packages/components/src/components/DaInsaneAd.vue
+++ b/packages/components/src/components/DaInsaneAd.vue
@@ -26,10 +26,10 @@ export default {
   computed: {
     cls() {
       return {
-        hover: this.selected
-      }
+        hover: this.selected,
+      };
     },
-  }
+  },
 };
 </script>
 

--- a/packages/components/src/components/DaInsanePost.vue
+++ b/packages/components/src/components/DaInsanePost.vue
@@ -66,7 +66,7 @@ export default {
         read: this.post.read,
         'menu-opened': this.menuOpened,
         'hide-menu': !this.showMenu,
-        hover: this.selected
+        hover: this.selected,
       };
     },
   },

--- a/packages/components/src/directives/tooltip.js
+++ b/packages/components/src/directives/tooltip.js
@@ -20,18 +20,17 @@ export default function (Vue) {
         return element.ownerDocument.body;
       case '#document':
         return element.body;
+      default: {
+        const getStyleComputedProp = getComputedStyle(element);
+        const { overflow, overflowX, overflowY } = getStyleComputedProp;
+
+        if (/(auto|scroll|overlay)/.test(overflow + overflowY + overflowX)) {
+          return element;
+        }
+
+        return getScrollParent(element.parentNode);
+      }
     }
-
-    const getStyleComputedProp = getComputedStyle(element);
-    const overflow = getStyleComputedProp.overflow;
-    const overflowX = getStyleComputedProp.overflowX;
-    const overflowY = getStyleComputedProp.overflowY;
-
-    if (/(auto|scroll|overlay)/.test(overflow + overflowY + overflowX)) {
-      return element;
-    }
-
-    return getScrollParent(element.parentNode);
   };
 
   const getPlacement = (modifiers) => {
@@ -72,7 +71,8 @@ export default function (Vue) {
     vnode.content = value;
     vnode.placement = getPlacement(modifiers);
     vnode.show = true;
-    setTimeout(() => positionTooltip(el, vnode.$el, vnode.placement, appendTo === document.body ? window.scrollY : appendTo.scrollTop), 10);
+    const scrollY = appendTo === document.body ? window.scrollY : appendTo.scrollTop;
+    setTimeout(() => positionTooltip(el, vnode.$el, vnode.placement, scrollY), 10);
   };
 
   const hideTooltip = (el) => {

--- a/packages/components/src/directives/tooltip.js
+++ b/packages/components/src/directives/tooltip.js
@@ -4,9 +4,35 @@ import DaTooltip from '../components/DaTooltip.vue';
 export default function (Vue) {
   const DaTooltipClass = Vue.extend(DaTooltip);
   let vnode = null;
+  let appendedTo = null;
   let targetElement = null;
   let overTimeout = null;
   let outTimeout = null;
+
+  const getScrollParent = (element) => {
+    if (!element) {
+      return document.body;
+    }
+
+    switch (element.nodeName) {
+      case 'HTML':
+      case 'BODY':
+        return element.ownerDocument.body;
+      case '#document':
+        return element.body;
+    }
+
+    const getStyleComputedProp = getComputedStyle(element);
+    const overflow = getStyleComputedProp.overflow;
+    const overflowX = getStyleComputedProp.overflowX;
+    const overflowY = getStyleComputedProp.overflowY;
+
+    if (/(auto|scroll|overlay)/.test(overflow + overflowY + overflowX)) {
+      return element;
+    }
+
+    return getScrollParent(element.parentNode);
+  };
 
   const getPlacement = (modifiers) => {
     const keys = Object.keys(modifiers);
@@ -16,38 +42,45 @@ export default function (Vue) {
     return 'top';
   };
 
-  const positionTooltip = (target, tooltip, placement) => {
+  const positionTooltip = (target, tooltip, placement, scrollY) => {
     const targetRect = target.getBoundingClientRect();
     const tooltipRect = tooltip.getBoundingClientRect();
     tooltip.removeAttribute('style');
     tooltip.style.position = 'absolute';
     tooltip.style.left = `${targetRect.left + (targetRect.width - tooltipRect.width) / 2}px`;
     if (placement === 'top') {
-      tooltip.style.top = `${targetRect.top + window.scrollY - tooltipRect.height - 5}px`;
+      tooltip.style.top = `${targetRect.top + scrollY - tooltipRect.height - 5}px`;
     } else {
-      tooltip.style.top = `${targetRect.bottom + window.scrollY + 5}px`;
+      tooltip.style.top = `${targetRect.bottom + scrollY + 5}px`;
     }
   };
 
   const createTooltip = () => {
     vnode = new DaTooltipClass();
     vnode.$mount();
-    document.body.appendChild(vnode.$el);
   };
 
   const showTooltip = (el, value, modifiers) => {
+    const appendTo = getScrollParent(el.parentNode);
+    if (appendedTo !== appendTo) {
+      appendTo.appendChild(vnode.$el);
+      appendedTo = appendTo;
+    }
+
     targetElement = el;
     el.setAttribute('aria-describedby', 'toolip');
     vnode.content = value;
     vnode.placement = getPlacement(modifiers);
     vnode.show = true;
-    setTimeout(() => positionTooltip(el, vnode.$el, vnode.placement), 10);
+    setTimeout(() => positionTooltip(el, vnode.$el, vnode.placement, appendTo === document.body ? window.scrollY : appendTo.scrollTop), 10);
   };
 
   const hideTooltip = (el) => {
     targetElement = null;
     el.removeAttribute('aria-describedby');
     vnode.show = false;
+    appendedTo.removeChild(vnode.$el);
+    appendedTo = false;
   };
 
   const removeEvents = (el) => {

--- a/packages/extension/src/components/DaSidebar.vue
+++ b/packages/extension/src/components/DaSidebar.vue
@@ -357,6 +357,7 @@ export default {
 }
 
 .sidebar__wrapper {
+  position: relative;
   width: 100%;
   height: 100%;
   overflow-y: scroll;


### PR DESCRIPTION
Until this commit the tooltip was always appended to the body element.
This caused edge cases where the tooltip wasn't scrolled when there was other scrollable element. In this commit, the tooltip is appended to the first scrollable parent of the target element.

Closes dailydotdev/daily#150