### PR TITLE
feat(components): add title to post cards

### DIFF
--- a/packages/components/src/components/DaLineClamp.vue
+++ b/packages/components/src/components/DaLineClamp.vue
@@ -1,5 +1,5 @@
 <template>
-  <span ref="content" :aria-label="text"></span>
+  <span ref="content" :aria-label="text" :title="text"></span>
 </template>
 
 <script>

--- a/packages/components/src/components/DaLineClamp.vue
+++ b/packages/components/src/components/DaLineClamp.vue
@@ -1,5 +1,5 @@
 <template>
-  <span ref="content" :aria-label="text" :title="text"></span>
+  <span ref="content" :title="text"></span>
 </template>
 
 <script>


### PR DESCRIPTION
Add title attribute to post cards, with the full text of post title.
So that the full title of the post can be seen by hovering on the post.

Resolves dailydotdev/daily#152