### PR TITLE
chore: add docker-compose file for local dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,70 @@
+version: "3"
+
+volumes:
+  db:
+
+services:
+  daily-postgres:
+    image: postgres:11.6-alpine
+    ports:
+      - "5432:5432"
+    volumes:
+      - db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_DB=api
+      - POSTGRES_PASSWORD=12345
+
+  daily-mysql:
+    image: gcr.io/daily-ops/mysql
+    ports:
+      - "3306:3306"
+
+  daily-gateway:
+    image: gcr.io/daily-ops/daily-gateway
+    depends_on:
+      - "daily-mysql"
+    volumes:
+      - ./wait-for.sh:/wait-for.sh
+    command: ["./wait-for.sh", "daily-mysql:3306", "--", "yarn", "start"]
+    ports:
+      - "4000:4000"
+    environment:
+      - MYSQL_USER=root
+      - MYSQL_PASSWORD=12345
+      - MYSQL_DATABASE=gateway
+      - MYSQL_HOST=daily-mysql
+      - COOKIES_DOMAIN=localhost
+      - COOKIES_KEY=topsecret
+      - GITHUB_CLIENT_ID=7b514cee17923d0acedc
+      - GITHUB_CLIENT_SECRET=064d875c7b370d271be839242538c87ab8bb6f92
+      - GOOGLE_CLIENT_ID=750405661228-fmeg35uuaopbcnc4c6m6g51755s355bm.apps.googleusercontent.com
+      - GOOGLE_CLIENT_SECRET=MMv_wZAS6Etoleg-sn__BlDC
+      - URL_PREFIX=http://localhost:4000
+      - JWT_SECRET='|r+.2!!!.Qf_-|63*%.D'
+      - JWT_AUDIENCE='Daily Staging'
+      - JWT_ISSUER='Daily API Staging'
+      - CORS_ORIGIN='http://,chrome-extension://,moz-extension://'
+      - PORT=4000
+      - API_URL=http://daily-api:5000
+      - API_SECRET=topsecret
+
+  daily-api:
+    image: gcr.io/daily-ops/daily-api
+    depends_on:
+      - "daily-postgres"
+    volumes:
+      - ./wait-for.sh:/wait-for.sh
+    command: ["./wait-for.sh", "daily-postgres:5432", "--", "npm", "run", "start"]
+    ports:
+      - "5000:5000"
+    environment:
+      - TYPEORM_HOST=daily-postgres
+      - PORT=5000
+      - TZ=UTC
+      - ACCESS_SECRET='topsecret'
+      - GATEWAY_URL=http://daily-gateway:4000
+      - GATEWAY_SECRET=topsecret
+      - DEFAULT_IMAGE_URL=https://res.cloudinary.com/daily-now/image/upload/f_auto/v1/placeholders/1,https://res.cloudinary.com/daily-now/image/upload/f_auto/v1/placeholders/2,https://res.cloudinary.com/daily-now/image/upload/f_auto/v1/placeholders/3,https://res.cloudinary.com/daily-now/image/upload/f_auto/v1/placeholders/4,https://res.cloudinary.com/daily-now/image/upload/f_auto/v1/placeholders/5,https://res.cloudinary.com/daily-now/image/upload/f_auto/v1/placeholders/6,https://res.cloudinary.com/daily-now/image/upload/f_auto/v1/placeholders/7,https://res.cloudinary.com/daily-now/image/upload/f_auto/v1/placeholders/8
+      - DEFAULT_IMAGE_RATIO=1
+      - DEFAULT_IMAGE_PLACEHOLDER=data:image/jpeg;base64,/9j/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAAKAAoDASIAAhEBAxEB/8QAFwAAAwEAAAAAAAAAAAAAAAAABAUGB//EACYQAAIABAQGAwAAAAAAAAAAAAECAAMEBRESE0IGByExQVFScZH/xAAVAQEBAAAAAAAAAAAAAAAAAAABA//EABURAQEAAAAAAAAAAAAAAAAAAAAR/9oADAMBAAIRAxEAPwCgPMKtsdvWjpamiGsuCBVZzn3NmOAB+wYUni23kkz71OM09XObd5jBKufNagklprk4jux9QBqP82/YpQ//2Q==
+      - URL_PREFIX=http://localhost:4000

--- a/wait-for.sh
+++ b/wait-for.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+WAIT_TIMEOUT=15
+WAIT_QUIET=0
+
+echoerr() {
+  if [ "$WAIT_QUIET" -ne 1 ]; then printf "%s\n" "$*" 1>&2; fi
+}
+
+usage() {
+  exitcode="$1"
+  cat << USAGE >&2
+Usage:
+  $cmdname host:port [-t timeout] [-- command args]
+  -q | --quiet                        Do not output any status messages
+  -t TIMEOUT | --timeout=timeout      Timeout in seconds, zero for no timeout
+  -- COMMAND ARGS                     Execute command with args after the test finishes
+USAGE
+  exit "$exitcode"
+}
+
+wait_for() {
+  for i in `seq $WAIT_TIMEOUT` ; do
+    nc -z "$WAIT_HOST" "$WAIT_PORT" > /dev/null 2>&1
+
+    result=$?
+    if [ $result -eq 0 ] ; then
+      if [ $# -gt 0 ] ; then
+        exec "$@"
+      fi
+      exit 0
+    fi
+    sleep 1
+  done
+  echo "Operation timed out" >&2
+  exit 1
+}
+
+while [ $# -gt 0 ]
+do
+  case "$1" in
+    *:* )
+    WAIT_HOST=$(printf "%s\n" "$1"| cut -d : -f 1)
+    WAIT_PORT=$(printf "%s\n" "$1"| cut -d : -f 2)
+    shift 1
+    ;;
+    -q | --quiet)
+    WAIT_QUIET=1
+    shift 1
+    ;;
+    -t)
+    WAIT_TIMEOUT="$2"
+    if [ "$WAIT_TIMEOUT" = "" ]; then break; fi
+    shift 2
+    ;;
+    --timeout=*)
+    WAIT_TIMEOUT="${1#*=}"
+    shift 1
+    ;;
+    --)
+    shift
+    break
+    ;;
+    --help)
+    usage 0
+    ;;
+    *)
+    echoerr "Unknown argument: $1"
+    usage 1
+    ;;
+  esac
+done
+
+if [ "$WAIT_HOST" = "" -o "$WAIT_PORT" = "" ]; then
+  echoerr "Error: you need to provide a host and port to test."
+  usage 2
+fi
+
+wait_for "$@"


### PR DESCRIPTION
Add a docker-compose config file that serves different containers needed to start the local environment for development. the containers are:
1. daily-mysql
1. daily-postgres
1. daily-gateway
1. daily-api

* used wait-for.sh script from https://github.com/eficode/wait-for in order to wait for database initialization before running app containers