### PR TITLE
refactor: prioritize fetching on boot

### DIFF
--- a/packages/extension/__tests__/Home.js
+++ b/packages/extension/__tests__/Home.js
@@ -10,8 +10,10 @@ import DaHeader from '../src/components/DaHeader.vue';
 import DaSidebar from '../src/components/DaSidebar.vue';
 import DaFeed from '../src/components/DaFeed.vue';
 import { createDummyEvent } from './fixtures/helpers';
-import { LATEST_NOTIFICATIONS_QUERY } from '../src/common/graphql';
+import { LATEST_NOTIFICATIONS_QUERY } from '../src/graphql/home';
+import { SOURCES_QUERY } from '../src/graphql/sidebar';
 import { apolloClient } from '../src/apollo';
+import { POPULAR_TAGS_QUERY } from '../src/graphql/tags';
 
 jest.mock('../src/apollo');
 
@@ -53,6 +55,7 @@ beforeEach(() => {
     },
     actions: {
       search: jest.fn(),
+      fetchNextFeedPage: jest.fn(),
     },
     getters: {
       feed: state => state.posts,
@@ -90,6 +93,9 @@ beforeEach(() => {
     },
     getters: {
       isLoggedIn: state => !!state.profile,
+    },
+    actions: {
+      validateAuth: jest.fn(),
     },
   };
 
@@ -172,6 +178,8 @@ it('should show banner when data is available', (done) => {
 
 it('should fetch notifications and update badge', (done) => {
   const now = new Date();
+  apolloClient.setRequestHandler(SOURCES_QUERY, () => Promise.resolve({data: { sources: {} }}));
+  apolloClient.setRequestHandler(POPULAR_TAGS_QUERY, () => Promise.resolve({data: { popularTags: {} }}));
   apolloClient.setRequestHandler(
     LATEST_NOTIFICATIONS_QUERY,
     () => Promise.resolve({ data: { latestNotifications: [{html: 'hello world', timestamp: now.toISOString()}] } }));

--- a/packages/extension/__tests__/Step2.js
+++ b/packages/extension/__tests__/Step2.js
@@ -1,27 +1,30 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex';
+import VueApollo from 'vue-apollo';
 import VueRouter from 'vue-router';
 import icons from '@daily/components/src/icons';
-import { contentService } from '../src/common/services';
 import Step2 from '../src/routes/Step2.vue';
+import { apolloClient } from '../src/apollo';
+import { SEARCH_TAGS_QUERY, POPULAR_TAGS_QUERY } from '../src/graphql/tags';
 
-jest.mock('../src/common/services', () => ({
-  contentService: {
-    searchTags: jest.fn(),
-    fetchPopularTags: jest.fn(),
-  },
-}));
+jest.mock('../src/apollo');
 
 const router = new VueRouter();
 const localVue = createLocalVue();
 
 localVue.use(Vuex);
+localVue.use(VueApollo);
 localVue.use(VueRouter);
 localVue.use(icons);
 
 let feed;
 let ui;
 let store;
+let popularTagsHandler = jest.fn();
+let searchTagsHandler = jest.fn();
+
+apolloClient.setRequestHandler(POPULAR_TAGS_QUERY, popularTagsHandler);
+apolloClient.setRequestHandler(SEARCH_TAGS_QUERY, searchTagsHandler);
 
 beforeEach(() => {
   window.ga = () => {
@@ -30,10 +33,7 @@ beforeEach(() => {
   feed = {
     namespaced: true,
     state: {
-      tags: [
-        { name: 'angular', enabled: false },
-        { name: 'vue', enabled: true },
-      ],
+      enabledTags: { vue: true },
     },
     actions: {
       setEnableTag: jest.fn(),
@@ -54,68 +54,69 @@ beforeEach(() => {
     modules: { feed, ui },
   });
 
-  contentService.fetchPopularTags.mockReturnValue([
-    { name: 'vue' },
-    { name: 'node' },
-    { name: 'javascript' },
-    { name: 'python' },
-    { name: 'docker' },
-    { name: 'devops' },
-  ]);
-});
-
-it('should fetch popular tags on mount', (done) => {
-  const wrapper = shallowMount(Step2, {
-    store,
-    localVue,
-  });
-
-  wrapper.vm.$nextTick(() => {
-    expect(contentService.fetchPopularTags).toBeCalledTimes(1);
-    expect(wrapper.vm.activeCounter).toEqual(true);
-    expect(wrapper.vm.disableButton).toEqual(true);
-    expect(wrapper.vm.tags).toEqual([
-      { name: 'vue', enabled: true },
-      { name: 'node', enabled: false },
-      { name: 'javascript', enabled: false },
-      { name: 'python', enabled: false },
-      { name: 'docker', enabled: false },
-      { name: 'devops', enabled: false },
-    ]);
-    done();
-  });
-});
-
-it('should enable tag when clicking on the relevant button', (done) => {
-  const wrapper = shallowMount(Step2, {
-    store,
-    localVue,
-  });
-
-  wrapper.vm.$nextTick(() => {
-    wrapper.find('.tags__buttons .btn').trigger('click');
-    expect(feed.actions.setEnableTag)
-      .toBeCalledWith(expect.anything(), { tag: feed.state.tags[1], enabled: false });
-    done();
-  });
-});
-
-it('should search for tags on new search input', () => {
-  contentService.searchTags.mockReturnValue({
+  popularTagsHandler.mockReset();
+  popularTagsHandler.mockResolvedValue({ data: { popularTags:
+    [
+      { name: 'vue' },
+      { name: 'node' },
+      { name: 'javascript' },
+      { name: 'python' },
+      { name: 'docker' },
+      { name: 'devops' },
+    ]
+  }});
+  searchTagsHandler.mockReset();
+  searchTagsHandler.mockResolvedValue({ data: { searchTags: {
     query: 'cl',
     hits: [
       { name: 'cloud' },
     ],
-  });
+  }}});
+});
 
+it('should fetch popular tags on mount', async () => {
   const wrapper = shallowMount(Step2, {
     store,
     localVue,
+    apolloProvider: new VueApollo({defaultClient: apolloClient }),
+  });
+  expect(popularTagsHandler).toBeCalledTimes(1);
+  await wrapper.vm.$nextTick();
+  expect(wrapper.vm.activeCounter).toEqual(true);
+  expect(wrapper.vm.disableButton).toEqual(true);
+  expect(wrapper.vm.tags).toEqual([
+    { name: 'vue', enabled: true },
+    { name: 'node', enabled: false },
+    { name: 'javascript', enabled: false },
+    { name: 'python', enabled: false },
+    { name: 'docker', enabled: false },
+    { name: 'devops', enabled: false },
+  ]);
+});
+
+it('should enable tag when clicking on the relevant button', async () => {
+  const wrapper = shallowMount(Step2, {
+    store,
+    localVue,
+    apolloProvider: new VueApollo({defaultClient: apolloClient }),
+  });
+
+  await wrapper.vm.$nextTick();
+  wrapper.find('.tags__buttons .btn').trigger('click');
+  expect(feed.actions.setEnableTag)
+    .toBeCalledWith(expect.anything(), { tag: 'vue', enabled: false });
+});
+
+it('should search for tags on new search input', () => {
+  const wrapper = shallowMount(Step2, {
+    store,
+    localVue,
+    apolloProvider: new VueApollo({defaultClient: apolloClient }),
   });
 
   wrapper.vm.$refs.searchTags.value = 'cl';
   wrapper.find('input').trigger('input');
-  expect(contentService.searchTags).toBeCalledWith('cl');
+  expect(searchTagsHandler).toBeCalledWith({ query: 'cl' });
 });
 
 it('should skip onboarding on skip button click', () => {
@@ -123,6 +124,7 @@ it('should skip onboarding on skip button click', () => {
     store,
     router,
     localVue,
+    apolloProvider: new VueApollo({defaultClient: apolloClient }),
   });
 
   wrapper.find('.btn-skip').trigger('click');

--- a/packages/extension/__tests__/__snapshots__/DaSidebar.js.snap
+++ b/packages/extension/__tests__/__snapshots__/DaSidebar.js.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SEARCH: Publications should display all the publications if the input value is empty 1`] = `
+Array [
+  Object {
+    "enabled": true,
+    "id": "airbnb",
+    "image": "https://res.cloudinary.com/daily-now/image/upload/t_logo,f_auto/v1/logos/airbnb",
+    "name": "Airbnb Engineering",
+  },
+  Object {
+    "enabled": false,
+    "id": "alligator",
+    "image": "https://res.cloudinary.com/daily-now/image/upload/t_logo,f_auto/v1/logos/alligator",
+    "name": "Alligator",
+  },
+  Object {
+    "enabled": false,
+    "id": "angular",
+    "image": "https://res.cloudinary.com/daily-now/image/upload/t_logo,f_auto/v1/logos/angular",
+    "name": "Angular",
+  },
+  Object {
+    "enabled": true,
+    "id": "aws",
+    "image": "https://res.cloudinary.com/daily-now/image/upload/t_logo,f_auto/v1/logos/aws",
+    "name": "AWS",
+  },
+]
+`;

--- a/packages/extension/__tests__/user.js
+++ b/packages/extension/__tests__/user.js
@@ -54,7 +54,6 @@ it('should authenticate user and check for bookmarks conflicts', async () => {
     [{ type: 'login', payload: profile }],
   );
   expect(authService.authenticate).toBeCalledWith('12345', 'verifier');
-  // expect(contentService.setIsLoggedIn).toBeCalledWith(true);
 });
 
 it('should authenticate user without checking for conflicts', async () => {
@@ -97,7 +96,6 @@ it('should logout and reset all preferences', async () => {
     [{ type: 'ui/reset', payload: null }, { type: 'feed/reset', payload: null }],
   );
   expect(setCache).toBeCalledWith(ANALYTICS_ID_KEY, '1');
-  expect(contentService.setIsLoggedIn).toBeCalledWith(false);
 });
 
 it('should set code challenge in state', () => {
@@ -179,5 +177,4 @@ it('should mark user as logged-in', async () => {
     state,
     [{ type: 'setProfile', payload: profile }],
   );
-  expect(contentService.setIsLoggedIn).toBeCalledWith(true);
 });

--- a/packages/extension/src/common/services.js
+++ b/packages/extension/src/common/services.js
@@ -4,7 +4,7 @@ import {
 
 const app = 'extension';
 // eslint-disable-next-line import/prefer-default-export
-export const contentService = new ContentServiceImpl(process.env.VUE_APP_API_URL, 30, app);
+export const contentService = new ContentServiceImpl(process.env.VUE_APP_API_URL, app);
 export const monetizationService = new MonetizationServiceImpl(process.env.VUE_APP_API_URL, app);
 export const profileService = new ProfileServiceImpl(process.env.VUE_APP_API_URL, app);
 export const authService = new AuthServiceImpl(process.env.VUE_APP_API_URL, app);

--- a/packages/extension/src/graphql/feed.js
+++ b/packages/extension/src/graphql/feed.js
@@ -1,19 +1,5 @@
 import gql from 'graphql-tag';
 
-export const BANNER_QUERY = gql`
-query Banner($lastSeen: DateTime) {
-  banner(lastSeen: $lastSeen) {
-    timestamp, cta, subtitle, theme, title, url
-  }
-}`;
-
-export const LATEST_NOTIFICATIONS_QUERY = gql`
-query LatestNotifications {
-  latestNotifications {
-    timestamp, html
-  }
-}`;
-
 export const FEED_POST_FRAGMENT = gql`
 fragment FeedPost on Post {
   id,title,url,publishedAt,createdAt,image,ratio,placeholder,readTime,source { id, name, image },tags

--- a/packages/extension/src/graphql/home.js
+++ b/packages/extension/src/graphql/home.js
@@ -1,0 +1,15 @@
+import gql from 'graphql-tag';
+
+export const BANNER_QUERY = gql`
+query Banner($lastSeen: DateTime) {
+  banner(lastSeen: $lastSeen) {
+    timestamp, cta, subtitle, theme, title, url
+  }
+}`;
+
+export const LATEST_NOTIFICATIONS_QUERY = gql`
+query LatestNotifications {
+  latestNotifications {
+    timestamp, html
+  }
+}`;

--- a/packages/extension/src/graphql/sidebar.js
+++ b/packages/extension/src/graphql/sidebar.js
@@ -1,0 +1,13 @@
+import gql from 'graphql-tag';
+
+// eslint-disable-next-line import/prefer-default-export
+export const SOURCES_QUERY = gql`
+query Sources {
+    sources(first: 500) {
+        edges {
+            node {
+                id, image, name
+            }
+        }
+    }
+}`;

--- a/packages/extension/src/graphql/tags.js
+++ b/packages/extension/src/graphql/tags.js
@@ -1,0 +1,16 @@
+import gql from 'graphql-tag';
+
+export const POPULAR_TAGS_QUERY = gql`
+query PopularTags {
+    popularTags {
+        name
+    }
+}`;
+
+export const SEARCH_TAGS_QUERY = gql`
+query SearchTags($query: String!) {
+    searchTags(query: $query) {
+        query
+        hits { name }
+    }
+}`;

--- a/packages/extension/src/standalone/standalone.js
+++ b/packages/extension/src/standalone/standalone.js
@@ -16,7 +16,6 @@ const apolloProvider = new VueApollo({
   defaultClient: apolloClient,
   defaultOptions: {
     $query: {
-      fetchPolicy: 'cache-only',
       notifyOnNetworkStatusChange: false,
     },
   },

--- a/packages/extension/src/store/index.js
+++ b/packages/extension/src/store/index.js
@@ -7,7 +7,6 @@ import sync from './plugins/sync';
 import ui from './modules/ui';
 import feed from './modules/feed';
 import user from './modules/user';
-import { contentService } from '../common/services';
 
 Vue.use(Vuex);
 
@@ -44,13 +43,26 @@ export default new Vuex.Store({
           state.feed.posts = (cached.feed.posts || []).map(cache2Post);
           state.feed.bookmarks = (cached.feed.bookmarks || []).map(cache2Post);
           state.feed.conflictBookmarks = (cached.feed.conflictBookmarks || []).map(cache2Post);
+          if (cached.feed.publications) {
+            delete state.feed.publications;
+            state.feed.disabledPublications = cached.feed.publications.reduce((acc, val) => {
+              if (!val.enabled) {
+                return { ...acc, [val.id]: true };
+              }
+              return acc;
+            }, {});
+          }
+          if (cached.feed.tags) {
+            delete state.feed.tags;
+            state.feed.enabledTags = cached.feed.tags.reduce((acc, val) => {
+              if (!val.enabled) {
+                return { ...acc, [val.name]: true };
+              }
+              return acc;
+            }, {});
+          }
         }
       }
-
-      if (state.user.profile) {
-        contentService.setIsLoggedIn(true);
-      }
-
       state.initialized = true;
     },
   },

--- a/packages/extension/src/store/modules/user.js
+++ b/packages/extension/src/store/modules/user.js
@@ -1,4 +1,4 @@
-import { authService, contentService } from '../../common/services';
+import { authService } from '../../common/services';
 import { setCache, ANALYTICS_ID_KEY } from '../../common/cache';
 
 const updateAnalyticsUser = (id) => {
@@ -32,7 +32,6 @@ export default {
   },
   actions: {
     async login({ commit, state }, profile) {
-      contentService.setIsLoggedIn(true);
       if (!state.profile || state.profile.id !== profile.id) {
         await updateAnalyticsUser(profile.id);
       }
@@ -56,7 +55,6 @@ export default {
 
     async logout({ commit, dispatch }) {
       // TODO: handle error
-      contentService.setIsLoggedIn(false);
       commit('setProfile', null);
       await authService.logout();
       await Promise.all([
@@ -73,10 +71,10 @@ export default {
 
     async validateAuth({ dispatch, state }) {
       const profile = await authService.getUserProfile();
-      if (profile.providers) {
+      if (profile.providers && (!state.profile || state.profile.id !== profile.id)) {
         // Keep newUser true according multiple sessions until confirmed
         await dispatch('login', Object.assign({}, profile, { newUser: state.profile && state.profile.newUser }));
-      } else if (state.profile) {
+      } else if (!profile.providers && state.profile) {
         await dispatch('logout');
       }
     },

--- a/packages/extension/src/store/plugins/cache.js
+++ b/packages/extension/src/store/plugins/cache.js
@@ -16,9 +16,9 @@ const stateToCache = (state) => {
   const toCache = Object.assign({}, state);
   delete toCache.initialized;
   toCache.feed = {
-    tags: state.feed.tags.filter(t => t.enabled).map(vue2Json),
-    publications: state.feed.publications.map(vue2Json),
-    posts: state.feed.posts.slice(0, contentService.pageSize).map(post2Cache),
+    disabledPublications: state.feed.disabledPublications,
+    enabledTags: state.feed.enabledTags,
+    posts: [{ type: 'ad', loading: true }, ...state.feed.posts.slice(1, contentService.pageSize).map(post2Cache)],
     bookmarks: state.feed.bookmarks.map(post2Cache),
     latest: time2Cache(state.feed.latest),
   };

--- a/packages/moderator/__tests__/user.js
+++ b/packages/moderator/__tests__/user.js
@@ -1,14 +1,11 @@
 import module from '../src/store/modules/user';
-import { authService, contentService } from '../src/common/services';
+import { authService } from '../src/common/services';
 import { testAction } from './fixtures/helpers';
 
 jest.mock('../src/common/services', () => ({
   authService: {
     authenticate: jest.fn(),
     generateChallenge: jest.fn(),
-  },
-  contentService: {
-    setIsLoggedIn: jest.fn(),
   },
 }));
 
@@ -39,7 +36,6 @@ it('should authenticate user and set profile', async () => {
     [{ type: 'setProfile', payload: profile }],
   );
   expect(authService.authenticate).toBeCalledWith('12345', 'verifier');
-  expect(contentService.setIsLoggedIn).toBeCalledWith(true);
 });
 
 it('should set code challenge in state', () => {

--- a/packages/moderator/src/common/services.js
+++ b/packages/moderator/src/common/services.js
@@ -2,5 +2,5 @@ import {
   AuthServiceImpl, ContentServiceImpl,
 } from '@daily/services';
 
-export const contentService = new ContentServiceImpl(process.env.VUE_APP_API_URL, 30);
+export const contentService = new ContentServiceImpl(process.env.VUE_APP_API_URL);
 export const authService = new AuthServiceImpl(process.env.VUE_APP_API_URL);

--- a/packages/moderator/src/store/index.js
+++ b/packages/moderator/src/store/index.js
@@ -1,6 +1,5 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
-import { contentService } from '../common/services';
 
 import user from './modules/user';
 import requests from './modules/requests';

--- a/packages/moderator/src/store/index.js
+++ b/packages/moderator/src/store/index.js
@@ -22,10 +22,6 @@ export default new Vuex.Store({
         });
       }
 
-      if (state.user.profile) {
-        contentService.setIsLoggedIn(true);
-      }
-
       state.initialized = true;
     },
   },

--- a/packages/moderator/src/store/modules/user.js
+++ b/packages/moderator/src/store/modules/user.js
@@ -23,7 +23,6 @@ export default {
   actions: {
     async authenticate({ commit, state }, { code }) {
       const profile = await authService.authenticate(code, state.challenge.verifier);
-      contentService.setIsLoggedIn(true);
       commit('setProfile', profile);
     },
     async generateChallenge({ commit }) {

--- a/packages/moderator/src/store/modules/user.js
+++ b/packages/moderator/src/store/modules/user.js
@@ -1,4 +1,4 @@
-import { authService, contentService } from '../../common/services';
+import { authService } from '../../common/services';
 
 const initialState = () => ({
   profile: null,


### PR DESCRIPTION
Add prioritization mechanism for fetching data when application is booting.
First level is critical data like feed and authentication details.
Second level is operational data like sources and tags.
Last level is engagement data like notifications and promotional banner.