### PR TITLE
fix: truncate text in sidebar

### DIFF
--- a/packages/extension/src/components/DaSidebar.vue
+++ b/packages/extension/src/components/DaSidebar.vue
@@ -382,6 +382,11 @@ export default {
   margin: 26px auto;
 }
 
+.sidebar__sources .text-overflow {
+  flex: 1;
+  text-align: start;
+}
+
 .sidebar__sources .sidebar__element,
 .sidebar__element.sidebar__search {
   height: 44px;


### PR DESCRIPTION
If the source name is too long it will be truncated with ellipsis method
Closes #122