### PR TITLE
fix(extension): show enabled tags even if not popular

### DIFF
--- a/packages/components/src/components/DaDropdown.vue
+++ b/packages/components/src/components/DaDropdown.vue
@@ -309,7 +309,7 @@ export default {
   color: var(--theme-primary);
   list-style: none;
   box-shadow: 0 16px 16px 0 rgba(0, 0, 0, 0.24);
-  z-index: 1;
+  z-index: 10;
   outline: 0;
   overflow-y: auto;
 

--- a/packages/extension/__tests__/DaSidebar.js
+++ b/packages/extension/__tests__/DaSidebar.js
@@ -67,7 +67,7 @@ beforeEach(() => {
     namespaced: true,
     state: {
       disabledPublications: { alligator: true, angular: true },
-      enabledTags: { javascript: true, linux: true },
+      enabledTags: { javascript: true, linux: true, webdev: true },
     },
     actions: {
       setFilter: jest.fn(),
@@ -167,6 +167,9 @@ it('should set enabledTags and disabledTags according to state', () => {
     'enabled': true,
   }, {
     'name': 'linux',
+    'enabled': true,
+  }, {
+    'name': 'webdev',
     'enabled': true,
   }]);
   expect(wrapper.vm.disabledTags).toEqual([{

--- a/packages/extension/src/components/DaIntegrations.vue
+++ b/packages/extension/src/components/DaIntegrations.vue
@@ -69,13 +69,19 @@ export default {
     rssFeeds: {
       query: RSS_FEEDS_QUERY,
       fetchPolicy: 'cache-and-network',
+      skip() {
+        return !this.isPremium;
+      },
     },
   },
 
   data() {
     return {
       copyTooltip: 'Copy',
-      rssFeeds: [],
+      rssFeeds: [
+        { url: 'https://placeholder.com', name: 'News feed' },
+        { url: 'https://placeholder2.com', name: 'Bookmarks' },
+      ],
       selectedFeed: 0,
     };
   },

--- a/packages/extension/src/components/DaSidebar.vue
+++ b/packages/extension/src/components/DaSidebar.vue
@@ -214,10 +214,16 @@ export default {
       if (!this.rawTags) {
         return [];
       }
-      return this.rawTags.map(t => ({
-        ...t,
-        enabled: !!this.$store.state.feed.enabledTags[t.name],
-      }));
+      const ret = this.rawTags.map(t => ({...t, enabled: false}));
+      Object.keys(this.$store.state.feed.enabledTags).forEach((t) => {
+        const i = ret.findIndex(t2 => t2.name === t);
+        if (i > -1) {
+          ret[i].enabled = true;
+        } else {
+          ret.push({ name: t, enabled: true });
+        }
+      });
+      return ret;
     },
     publications() {
       if (!this.rawPublications) {


### PR DESCRIPTION
Seached tags that were not part of the popular tags list were bugged and the user was unable to actually enable them

Closes dailydotdev/daily#163