### PR TITLE
Added Open as tab toggle, test cases, and functionality

### DIFF
--- a/packages/components/src/components/DaCard.vue
+++ b/packages/components/src/components/DaCard.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="card" :class="cls">
-    <a :href="url" class="card__link post__link" @click="$emit('click')">
+    <a :href="url" class="card__link post__link"
+      :target="tabbedOpen.openTab ? '_blank' : false"
+      @click="$emit('click');">
       <div class="card__background" :style="imgStyle">
         <img
           class="card__background__image lazyload"
@@ -74,6 +76,12 @@ export default {
     cls() {
       return {
         [this.size]: true,
+      };
+    },
+
+    tabbedOpen() {
+      return {
+        openTab: this.$store.getters['ui/openNewTab'],
       };
     },
   },

--- a/packages/components/src/components/DaInsanePost.vue
+++ b/packages/components/src/components/DaInsanePost.vue
@@ -2,7 +2,8 @@
   <div class="insane__wrapper">
     <div class="insane insane--post" :class="cls">
       <a :href="post.url" class="insane__link post__link"
-          @click="$emit('click', post)">
+          :target="tabbedOpen.openTab ? '_blank' : false"
+          @click="$emit('click', post);">
         <h5 class="insane__title">
           <da-line-clamp :text="post.title" :lines="3"/>
         </h5>
@@ -72,8 +73,13 @@ export default {
         hover: this.selected,
       };
     },
-  },
 
+    tabbedOpen() {
+      return {
+        openTab: this.$store.getters['ui/openNewTab'],
+      };
+    },
+  },
   mounted() {
     import('../../icons/bookmark');
     import('../../icons/menu');

--- a/packages/extension/__tests__/DaSettings.js
+++ b/packages/extension/__tests__/DaSettings.js
@@ -43,7 +43,7 @@ beforeEach(() => {
       setShowOnlyNotReadPosts: jest.fn(),
     },
   };
-  
+
   feed = {
     namespaced: true,
     state: {},
@@ -91,4 +91,10 @@ it('should commit "setShowOnlyNotReadPosts" when setting is changed', () => {
   const wrapper = mount(DaSettings, { store, localVue });
   wrapper.find('.settings__hide-read-posts').vm.$emit('toggle', true);
   expect(ui.mutations.setShowOnlyNotReadPosts).toBeCalledWith(expect.anything(), true);
+});
+
+it('should commit "setOpenNewTab" when setting is changed', () => {
+  const wrapper = mount(DaSettings, { store, localVue });
+  wrapper.find('.settings__toggle-open-tab').vm.$emit('toggle', true);
+  expect(ui.mutations.setOpenNewTab).toBeCalledWith(expect.anything(), true);
 });

--- a/packages/extension/__tests__/ui.js
+++ b/packages/extension/__tests__/ui.js
@@ -58,6 +58,12 @@ it('should set show only not read posts in state', () => {
   expect(state.showOnlyNotReadPosts).toEqual(true);
 });
 
+it('should set open links as tabs in state', () => {
+  const state = {};
+  module.mutations.setOpenNewTab(state, true);
+  expect(state.openNewTab).toEqual(true);
+});
+
 it('should set spaciness in state', () => {
   const state = {};
   module.mutations.setSpaciness(state, 'roomy');
@@ -91,14 +97,14 @@ it('should show notification badge when never seen notification', () => {
 
 it('should show notification badge when timestamp is newer than last seen', () => {
   const now = new Date();
-  const state = {lastNotificationTime: new Date(now.getTime() - 1000)};
+  const state = { lastNotificationTime: new Date(now.getTime() - 1000) };
   module.mutations.updateNotificationBadge(state, now);
   expect(state.showNotificationBadge).toEqual(true);
 });
 
 it('should not show notification badge when timestamp is older than last seen', () => {
   const now = new Date();
-  const state = {lastNotificationTime: now};
+  const state = { lastNotificationTime: now };
   module.mutations.updateNotificationBadge(state, new Date(now.getTime() - 1000));
   expect(state.showNotificationBadge).toEqual(false);
 });

--- a/packages/extension/src/components/DaSettings.vue
+++ b/packages/extension/src/components/DaSettings.vue
@@ -23,6 +23,8 @@
                  :checked="enableCardAnimations" @toggle="toggleCardAnimations"/>
       <da-switch label="Hide read posts" class="small settings__hide-read-posts"
                  :checked="showOnlyNotReadPosts" @toggle="toggleShowOnlyNotReadPosts"/>
+      <da-switch label="Open Links in New Tab" class="small settings__toggle-open-tab"
+                 :checked="openNewTab" @toggle="toggleOpenInTab"/>
     </div>
   </div>
 </template>
@@ -50,7 +52,7 @@ export default {
   },
   computed: {
     ...mapState('ui', [
-      'showTopSites', 'insaneMode', 'spaciness', 'enableCardAnimations', 'showOnlyNotReadPosts',
+      'showTopSites', 'insaneMode', 'spaciness', 'enableCardAnimations', 'showOnlyNotReadPosts', 'openNewTab',
     ]),
     ...mapState({
       theme: state => themes.indexOf(state.ui.theme),
@@ -74,6 +76,10 @@ export default {
       ga('send', 'event', 'Settings', 'Click', 'Hide Read Posts');
       this.$store.commit('ui/setShowOnlyNotReadPosts', val);
       this.refreshFeed();
+    },
+    async toggleOpenInTab(val) {
+      ga('send', 'event', 'Settings', 'Click', 'Open New Tab');
+      this.$store.commit('ui/setOpenNewTab', val);
     },
     toggleCardAnimations(val) {
       ga('send', 'event', 'Settings', 'Click', 'Card Animations');

--- a/packages/extension/src/store/modules/ui.js
+++ b/packages/extension/src/store/modules/ui.js
@@ -18,6 +18,7 @@ const initialState = () => ({
   lastBannerSeen: new Date(),
   showPremium: false,
   showNewSource: false,
+  openNewTab: false,
 });
 
 export default {
@@ -43,7 +44,9 @@ export default {
     setShowOnlyNotReadPosts(state, value) {
       state.showOnlyNotReadPosts = value;
     },
-
+    setOpenNewTab(state, value) {
+      state.openNewTab = value;
+    },
     setSpaciness(state, value) {
       state.spaciness = value;
     },
@@ -91,6 +94,7 @@ export default {
       state.showTopSites = def.showTopSites;
       state.enableCardAnimations = def.enableCardAnimations;
       state.showOnlyNotReadPosts = def.showOnlyNotReadPosts;
+      state.openNewTab = def.openNewTab;
     },
 
     doneOnboarding(state) {
@@ -128,6 +132,9 @@ export default {
 
     dndModeTime(state) {
       return state.dndModeTime;
+    },
+    openNewTab(state) {
+      return state.openNewTab;
     },
   },
   actions: {

--- a/packages/extension/src/store/plugins/sync.js
+++ b/packages/extension/src/store/plugins/sync.js
@@ -16,6 +16,7 @@ const syncSettings = (state) => {
       insaneMode: state.ui.insaneMode,
       spaciness: state.ui.spaciness,
       showOnlyNotReadPosts: state.ui.showOnlyNotReadPosts,
+      openNewTab: state.ui.openNewTab,
     });
   }
 
@@ -68,6 +69,7 @@ const plugin = (store) => {
       store.commit('ui/setEnableCardAnimations', settings.enableCardAnimations);
       store.commit('ui/setSpaciness', settings.spaciness);
       store.commit('ui/setShowOnlyNotReadPosts', settings.showOnlyNotReadPosts);
+      store.commit('ui/setOpenNewTab', settings.openNewTab);
       const pr1 = store.dispatch('ui/setTheme', settings.theme);
       const pr2 = contentService.fetchFeedPublications()
         .then(pubs => store.commit('feed/setDisabledPublications', Object.keys(pubs)));
@@ -103,6 +105,10 @@ const plugin = (store) => {
     case 'ui/setEnableCardAnimations':
     case 'ui/setSpaciness':
     case 'ui/setShowOnlyNotReadPosts':
+      // TODO: handle error
+      await syncSettings(state);
+      break;
+    case 'ui/setOpenNewTab':
       // TODO: handle error
       await syncSettings(state);
       break;

--- a/packages/services/src/profile.ts
+++ b/packages/services/src/profile.ts
@@ -10,6 +10,7 @@ export interface Settings {
   theme: string;
   spaciness: string;
   showOnlyNotReadPosts: boolean;
+  openNewTab: boolean;
 }
 
 export interface Notification {


### PR DESCRIPTION
Haven't written much vuejs before, so I may have misused the store in the `.vue` components:
https://github.com/NyWn/daily-apps/blob/dfa6baba0fc75567132c72afa80c29a694a89c3c/packages/components/src/components/DaCard.vue#L84
https://github.com/NyWn/daily-apps/blob/dfa6baba0fc75567132c72afa80c29a694a89c3c/packages/components/src/components/DaInsanePost.vue#L79

@idoshamun in your message explaining what to do, you mentioned `compatibility/settings.ts`, however I couldn't find this file, unless its `__tests__/DaSettings.js. 

I've probably missed something or broken some convention 😉 , but I reckon this is a decent starting point..