### PR TITLE
Make recently visited websites prominent on the top bar. Avoid favicon cropping. 

### DIFF
--- a/packages/extension/src/components/DaHeader.vue
+++ b/packages/extension/src/components/DaHeader.vue
@@ -281,16 +281,18 @@ export default {
   }
 
   & .header__top-site {
-    width: 24px;
-    height: 24px;
-    border-radius: 50%;
+    width: 28px;
+    height: 28px;
+    border-radius: 4px;
     border: 1px solid var(--color-pepper-70);
     overflow: hidden;
+    display: block;
+    background: #FFF;
   }
 
   & .top-site__image {
-    width: 23px;
-    height: 23px;
+    width: 100%;
+    display: block;
     background: var(--color-salt-10);
   }
 

--- a/packages/extension/src/components/DaHeader.vue
+++ b/packages/extension/src/components/DaHeader.vue
@@ -283,7 +283,7 @@ export default {
   & .header__top-site {
     width: 28px;
     height: 28px;
-    border-radius: 4px;
+    border-radius: 8px;
     border: 1px solid var(--color-pepper-70);
     overflow: hidden;
     display: block;

--- a/packages/extension/src/components/DaHeader.vue
+++ b/packages/extension/src/components/DaHeader.vue
@@ -287,7 +287,7 @@ export default {
     border: 1px solid var(--color-pepper-70);
     overflow: hidden;
     display: block;
-    background: #FFF;
+    background: var(--color-salt-10);
   }
 
   & .top-site__image {


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/6068418/94795924-ad0e4400-03fb-11eb-8adc-f555bd8756a6.png)


After:
![image](https://user-images.githubusercontent.com/6068418/94795876-9b2ca100-03fb-11eb-9173-4d19cb2272fc.png)
