### PR TITLE
fix: caching issue in firefox

### DIFF
--- a/packages/components/src/common/postMixin.js
+++ b/packages/components/src/common/postMixin.js
@@ -110,8 +110,8 @@ export default {
     },
 
     onCommentKeydown(event) {
-      // Ctrl + Enter
-      if (event.ctrlKey && event.keyCode === 13 && this.enablePostComment) {
+      // Ctrl / Command + Enter
+      if ((event.ctrlKey || event.metaKey) && event.keyCode === 13 && this.enablePostComment) {
         event.preventDefault();
         this.onPostCommentClick();
       }

--- a/packages/extension/src/manifest/development.json
+++ b/packages/extension/src/manifest/development.json
@@ -4,6 +4,6 @@
     "persistent": false
   },
   "permissions": [
-    "http://localhost:4000/"
+    "http://localhost/"
   ]
 }

--- a/packages/extension/src/store/plugins/cache.js
+++ b/packages/extension/src/store/plugins/cache.js
@@ -48,7 +48,7 @@ const stateToCache = (state) => {
   };
   toCache.user = vue2Json(state.user);
 
-  return toCache;
+  return JSON.parse(JSON.stringify(toCache));
 };
 
 const plugin = (store) => {


### PR DESCRIPTION
For some reason, Firefox cache was broken due to Vue reactive object.
It is now fixed using json stringify and parse.

Closes dailydotdev/daily#195