### PR TITLE
fix: allow toggling on/off recently visited sites

### DIFF
--- a/packages/components/src/components/DaSwitch.vue
+++ b/packages/components/src/components/DaSwitch.vue
@@ -36,18 +36,26 @@ export default {
     name: {
       type: String,
     },
+    immediateEvent: {
+      type: Boolean,
+      required: false,
+    },
   },
 
   methods: {
     toggle(event) {
-      // Need to wait for the long transition to prevent jagged animation
-      this.$refs.handle.addEventListener('transitionend', () => {
+      if (this.immediateEvent) {
+        this.$emit('toggle', event.target.checked);
+      } else {
+        // Need to wait for the long transition to prevent jagged animation
         this.$refs.handle.addEventListener('transitionend', () => {
-          setTimeout(() => {
-            this.$emit('toggle', event.target.checked);
-          });
+          this.$refs.handle.addEventListener('transitionend', () => {
+            setTimeout(() => {
+              this.$emit('toggle', event.target.checked);
+            });
+          }, { once: true });
         }, { once: true });
-      }, { once: true });
+      }
     },
   },
 };

--- a/packages/extension/src/components/DaHeader.vue
+++ b/packages/extension/src/components/DaHeader.vue
@@ -285,6 +285,7 @@ export default {
   & .header__top-site {
     width: 28px;
     height: 28px;
+    padding: 2px;
     border-radius: 8px;
     overflow: hidden;
     display: block;
@@ -295,6 +296,8 @@ export default {
     width: 100%;
     display: block;
     background: var(--color-salt-10);
+    border-radius: 8px;
+    overflow: hidden;
   }
 
   & .space {

--- a/packages/extension/src/components/DaSettings.vue
+++ b/packages/extension/src/components/DaSettings.vue
@@ -16,7 +16,7 @@
     <div class="settings__column">
       <h5>Preferences</h5>
       <da-switch label="Recently visited sites" class="small settings__top-sites"
-                 :checked="showTopSites" @toggle="toggleTopSites"/>
+                 :checked="showTopSites" @toggle="toggleTopSites" immediate-event/>
       <da-switch label="Light theme" class="small settings__theme"
                  :checked="theme > 0" @toggle="toggleTheme"/>
       <da-switch label="Hide read posts" class="small settings__hide-read-posts"


### PR DESCRIPTION
Due to timing issues the optional permission request was blocked by the browser.
Now the request is triggered immmediately with the mouse click event which fixes the issue.
Add padding to the icons of the recently visited sites