### PR TITLE
refactor: delay websocket connection to engagement phase

### DIFF
--- a/packages/extension/src/apollo.js
+++ b/packages/extension/src/apollo.js
@@ -36,6 +36,7 @@ const wsLink = new WebSocketLink({
   uri: process.env.VUE_APP_SUBS_URL,
   options: {
     reconnect: true,
+    lazy: true,
   },
 });
 

--- a/packages/extension/src/common/consts.js
+++ b/packages/extension/src/common/consts.js
@@ -1,0 +1,3 @@
+export const CRITICAL_FETCH_STAGE = 1;
+export const OPERATIONAL_FETCH_STAGE = 2;
+export const ENGAGEMENT_FETCH_STAGE = 4;

--- a/packages/extension/src/components/DaFeed.vue
+++ b/packages/extension/src/components/DaFeed.vue
@@ -80,6 +80,7 @@ import {
 import { contentService } from '../common/services';
 import { getCache, LAST_COMMENT_KEY, setCache } from '../common/cache';
 import { POSTS_ENGAGED_SUBSCRIPTION } from '../graphql/feed';
+import { ENGAGEMENT_FETCH_STAGE } from '../common/consts';
 
 export default {
   name: 'DaFeed',
@@ -95,6 +96,7 @@ export default {
   },
   props: {
     bookmarkLists: Array,
+    fetchStage: Number,
   },
   apollo: {
     $subscribe: {
@@ -104,7 +106,7 @@ export default {
           return { loggedIn: this.isLoggedIn, ids: this.posts.map(post => post.id) };
         },
         skip() {
-          return !this.posts || !this.posts.length;
+          return !this.posts || !this.posts.length || this.fetchStage < ENGAGEMENT_FETCH_STAGE;
         },
         result({ data }) {
           this.updatePost({ post: data.postsEngaged });

--- a/packages/extension/src/routes/Home.vue
+++ b/packages/extension/src/routes/Home.vue
@@ -134,7 +134,7 @@
         </div>
       </template>
       <da-feed v-else-if="showFeed" ref='feed' :bookmark-lists="bookmarkLists"
-               @login="onLogin('Feed')"/>
+               :fetch-stage="fetchStage" @login="onLogin('Feed')"/>
       <DaSpinner v-if="loading" class="feed-spinner"/>
     </main>
     <div id="anchor" ref="anchor"></div>
@@ -202,10 +202,7 @@ import DaSvg from '../components/DaSvg.vue';
 import DaFeed from '../components/DaFeed.vue';
 import { trackPageView } from '../common/analytics';
 import { navigateDaily, validKeys, validKeysValues } from '../common/keyNavigationService';
-
-const CRITICAL_FETCH_STAGE = 1;
-const OPERATIONAL_FETCH_STAGE = 2;
-const ENGAGEMENT_FETCH_STAGE = 4;
+import { CRITICAL_FETCH_STAGE, OPERATIONAL_FETCH_STAGE, ENGAGEMENT_FETCH_STAGE } from '../common/consts';
 
 export default {
   name: 'Home',


### PR DESCRIPTION
The rate of opening a daily.dev tab is very high and create load on our servers.
I decided to set the websocket connection to lazy and subscribe to postsEngaged as part of the engagement requests phase