### PR TITLE
refactor: disable counter animation before loading the first page

### DIFF
--- a/packages/components/src/common/postMixin.js
+++ b/packages/components/src/common/postMixin.js
@@ -45,6 +45,10 @@ export default {
       type: Boolean,
       default: true,
     },
+    disableCounter: {
+      type: Boolean,
+      default: false,
+    }
   },
 
   data() {

--- a/packages/components/src/components/DaCardPost.vue
+++ b/packages/components/src/components/DaCardPost.vue
@@ -76,7 +76,7 @@
         <button class="btn btn-menu" :class="{ 'post__action-completed': post.upvoted}"
                 @click="onUpvoteClick">
           <svgicon name="upvote" v-tooltip="'Upvote'"/>
-          <da-counter :value="post.numUpvotes" />
+          <da-counter :value="post.numUpvotes" :disable="disableCounter" />
         </button>
       </div>
       <div class="post__buttons__placeholder">
@@ -84,7 +84,7 @@
            :href="post.commentsPermalink" target="_blank"
            rel="noopener noreferrer" @click="onCommentClick">
           <svgicon name="comment" v-tooltip="'Comment'"/>
-          <da-counter :value="post.numComments" />
+          <da-counter :value="post.numComments" :disable="disableCounter" />
         </a>
       </div>
     </div>

--- a/packages/components/src/components/DaCounter.vue
+++ b/packages/components/src/components/DaCounter.vue
@@ -14,6 +14,10 @@ export default {
       type: Number,
       required: true,
     },
+    disable: {
+      type: Boolean,
+      default: false,
+    }
   },
   data() {
     return {
@@ -22,7 +26,7 @@ export default {
   },
   watch: {
     value(newValue, oldValue) {
-      if (newValue > oldValue) {
+      if (newValue > oldValue && !this.disable) {
         this.transition = 'counter-up';
       } else {
         this.transition = 'counter-down';

--- a/packages/components/src/components/DaInsanePost.vue
+++ b/packages/components/src/components/DaInsanePost.vue
@@ -58,7 +58,7 @@
           <button class="btn btn-menu" :class="{ 'post__action-completed': post.upvoted}"
                   @click="onUpvoteClick">
             <svgicon name="upvote" v-tooltip="'Upvote'"/>
-            <da-counter :value="post.numUpvotes" />
+            <da-counter :value="post.numUpvotes" :disable="disableCounter" />
           </button>
         </div>
         <div class="post__buttons__placeholder">
@@ -66,7 +66,7 @@
              :href="post.commentsPermalink" target="_blank"
              rel="noopener noreferrer" @click="onCommentClick">
             <svgicon name="comment" v-tooltip="'Comment'"/>
-            <da-counter :value="post.numComments" />
+            <da-counter :value="post.numComments" :disable="disableCounter" />
           </a>
         </div>
         <button class="btn-icon post__bookmark post__show-on-hover post__align-right"

--- a/packages/extension/src/components/DaFeed.vue
+++ b/packages/extension/src/components/DaFeed.vue
@@ -18,7 +18,8 @@
                         :bookmarks-menu-opened="bookmarkPostId === item.id"
                         :selected="focusedPost === item" :open-new-tab="openNewTab"
                         :show-comment-popup="commentPostId === item.id"
-                        :sending-comment="sendingComment" :comment="lastSavedComment"/>
+                        :sending-comment="sendingComment" :comment="lastSavedComment"
+                        :disable-counter="!pageInfo"/>
       </template>
     </div>
     <div class="feed__cards" v-else>
@@ -39,7 +40,8 @@
                       :bookmarks-menu-opened="bookmarkPostId === item.id"
                       :selected="focusedPost === item" :open-new-tab="openNewTab"
                       :show-comment-popup="commentPostId === item.id"
-                      :sending-comment="sendingComment" :comment="lastSavedComment"/>
+                      :sending-comment="sendingComment" :comment="lastSavedComment"
+                      :disable-counter="!pageInfo"/>
       </template>
     </div>
     <da-context ref="context" class="feed__context" @open="onPostMenuOpened"
@@ -126,7 +128,7 @@ export default {
   },
   computed: {
     ...mapState('ui', ['insaneMode', 'spaciness', 'openNewTab']),
-    ...mapState('feed', ['ads', 'hoveredPostAndIndex', 'showBookmarks', 'lastUsedBookmarkList']),
+    ...mapState('feed', ['ads', 'hoveredPostAndIndex', 'showBookmarks', 'lastUsedBookmarkList', 'pageInfo']),
     ...mapGetters({
       posts: 'feed/feed',
       isLoggedIn: 'user/isLoggedIn',

--- a/packages/extension/src/graphql/feed.js
+++ b/packages/extension/src/graphql/feed.js
@@ -107,6 +107,7 @@ export const COMMENT_ON_POST_MUTATION = gql`
 export const POSTS_ENGAGED_SUBSCRIPTION = gql`
   subscription PostsEngaged($ids: [ID]!) {
     postsEngaged(ids: $ids) {
+      id
       numComments
       numUpvotes
     }


### PR DESCRIPTION
When opening a new tab and seeing this counter animation all-around can very distractive.
I disabled the animation until the first feed page is loaded from the server.