### PR TITLE
refactor: validate authentication before proceeding with other requests

### DIFF
--- a/packages/extension/__tests__/ui.js
+++ b/packages/extension/__tests__/ui.js
@@ -68,7 +68,7 @@ it('should reset settings', () => {
     showTopSites: false,
     showOnlyNotReadPosts: false,
     openNewTab: true,
-    spaciness: 'roomy',
+    spaciness: 'eco',
   });
 });
 

--- a/packages/extension/src/routes/Home.vue
+++ b/packages/extension/src/routes/Home.vue
@@ -376,11 +376,10 @@ export default {
       }
     },
 
-    criticalFetch() {
-      const loadFeed = this.fetchNextFeedPage()
+    async criticalFetch() {
+      await this.validateAuth();
+      return this.fetchNextFeedPage()
         .then(() => requestIdleCallback(() => this.contentObserver.observe(this.$refs.anchor)));
-      const loadAuth = this.validateAuth();
-      return Promise.all([loadFeed, loadAuth]);
     },
 
     operationalFetch() {

--- a/packages/extension/src/store/modules/ui.js
+++ b/packages/extension/src/store/modules/ui.js
@@ -4,7 +4,7 @@ import { FIRST_INSTALL_KEY, getCache } from '../../common/cache';
 const initialState = () => ({
   theme: null,
   insaneMode: false,
-  spaciness: 'roomy',
+  spaciness: 'eco',
   dndModeTime: null,
   showDndMenu: false,
   showTopSites: false,

--- a/packages/extension/src/store/modules/user.js
+++ b/packages/extension/src/store/modules/user.js
@@ -1,4 +1,4 @@
-import { isToday, startOfToday, isThisISOWeek } from 'date-fns';
+import { isToday, startOfToday, isThisISOWeek, differenceInMilliseconds } from 'date-fns';
 import { apolloClient } from '../../apollo';
 import { authService } from '../../common/services';
 import { setCache, ANALYTICS_ID_KEY } from '../../common/cache';
@@ -110,6 +110,12 @@ export default {
           const redirectUri = browser.extension.getURL('index.html');
           window.location.href = `${profile.registrationLink}?redirect_uri=${encodeURI(redirectUri)}`;
           return;
+        }
+        if (profile.accessToken) {
+          const expiresInMillis = differenceInMilliseconds(new Date(), new Date(profile.accessToken.expiresIn));
+          // Refresh token before it expires
+          setTimeout(() => dispatch('validateAuth'), expiresInMillis - 1000 * 60 * 2);
+          profile.accessToken = undefined;
         }
         if (state.profile && state.profile.id === profile.id) {
           // Keep newUser true according multiple sessions until confirmed


### PR DESCRIPTION
Call the /users/me endpoint to refresh the access token before dispatching any other request